### PR TITLE
Fix react-script not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "node ./node_modules/react-scripts/bin/react-scripts.js test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Summary
- call react-scripts explicitly in test script

## Testing
- `npm test` *(fails: Cannot find module 'react-scripts')*

------
https://chatgpt.com/codex/tasks/task_b_685524340dac833091362a9990e34839